### PR TITLE
Adding more data options ('store_container' and 'open_to')

### DIFF
--- a/app/helpers/filepicker_rails/form_helper.rb
+++ b/app/helpers/filepicker_rails/form_helper.rb
@@ -7,7 +7,7 @@ module FilepickerRails
                                        :store_location, :store_access,
                                        :store_container, :multiple]
 
-    FILEPICKER_OPTIONS_TO_CAMELIZE = [:max_size, :max_files]
+    FILEPICKER_OPTIONS_TO_CAMELIZE = [:max_size, :max_files, :open_to]
 
     # Creates a filepicker field, accepts optional `options` hash for configuration.
     #
@@ -30,6 +30,7 @@ module FilepickerRails
     # - `:onchange` - The onchange event.
     # - `:max_size` - The maximum file size allowed, in bytes.
     # - `:max_files` - The maximum number of files.
+    # - `:open_to` - Open the picker to the given service. Ex: `COMPUTER`.
     # - `:class` - Add a class to the input.
     # - `:value` - Define the value of the input
     #

--- a/app/helpers/filepicker_rails/form_helper.rb
+++ b/app/helpers/filepicker_rails/form_helper.rb
@@ -4,7 +4,8 @@ module FilepickerRails
     FILEPICKER_OPTIONS_TO_DASHERIZE = [:button_text, :button_class, :mimetypes,
                                        :extensions, :container, :services,
                                        :drag_text, :drag_class, :store_path,
-                                       :store_location, :store_access, :multiple]
+                                       :store_location, :store_access,
+                                       :store_container, :multiple]
 
     FILEPICKER_OPTIONS_TO_CAMELIZE = [:max_size, :max_files]
 
@@ -21,6 +22,7 @@ module FilepickerRails
     # - `:services` - What services your users can upload to. Ex: `BOX, COMPUTER, FACEBOOK`.
     # - `:store_path` - The path to store the file at within the specified file store.
     # - `:store_location` - The file is not copied by default. It remains in the original location. If you wish you have the file copied onto your own storage, you can specify where we should put the copy. The only value at the moment is `S3`.
+    # - `:store_container` - The bucket or container in your specified `store_location`. Defaults to the container specified in the developer portal. Does not apply to Dropbox storage.
     # - `:store_access` - Should the underlying file be publicly available on its S3 link. Options are `public` and `private`, defaults to 'private'.
     # - `:dragdrop` - (`true` or `false`) Whether or not to allow drag-and-drop uploads.
     # - `:drag_text` - The text of the dragdrop pane.

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -122,6 +122,11 @@ RSpec.describe FilepickerRails::FormHelper do
         expect(form.filepicker_field(:filepicker_url, max_files: 10)).to include(attribute)
       end
 
+      it "have correct input with 'open_to'" do
+        attribute = %{data-fp-openTo="FACEBOOK"}
+        expect(form.filepicker_field(:filepicker_url, open_to: 'FACEBOOK')).to include(attribute)
+      end
+
       it "have correct input with 'onchange'" do
         attribute = %{onchange="track()"}
         expect(form.filepicker_field(:filepicker_url, onchange: "track()")).to include(attribute)

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -97,6 +97,11 @@ RSpec.describe FilepickerRails::FormHelper do
         expect(form.filepicker_field(:filepicker_url, store_location: "S3")).to include(attribute)
       end
 
+      it "have correct input with 'store_container'" do
+        attribute = %{data-fp-store-container="my-bucket"}
+        expect(form.filepicker_field(:filepicker_url, store_container: "my-bucket")).to include(attribute)
+      end
+
       it "have correct input with 'store_access'" do
         attribute = %{data-fp-store-access="public"}
         expect(form.filepicker_field(:filepicker_url, store_access: "public")).to include(attribute)


### PR DESCRIPTION
As per the [widget documentation page](https://developers.filepicker.io/docs/web/widgets/) I'm adding two options to support the `data-fp-store-container` and `data-fp-openTo` attributes.