### PR TITLE
Merge url options with query string if already present in url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.5.1 (July, 1, 2015)
+
+### improvements
+
+- Update `filepicker_image_url` to merge query params into current url params if they exist
+
 ## 1.5.0 (June, 10, 2015)
 
 ### features

--- a/lib/filepicker_rails/version.rb
+++ b/lib/filepicker_rails/version.rb
@@ -1,3 +1,3 @@
 module FilepickerRails
-  VERSION = "1.5.0"
+  VERSION = "1.5.1"
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -254,6 +254,13 @@ RSpec.describe FilepickerRails::ApplicationHelper do
       end
     end
 
+    context "with convert options provided and convert options already in the url" do
+      it "merges the options into the query params" do
+        url = filepicker_image_url("foo/convert?crop=0,0,1024,1024", watersize: 70)
+        expect(url).to eq("foo/convert?crop=0%2C0%2C1024%2C1024&watersize=70")
+      end
+    end
+
     context "with cdn host" do
 
       before do


### PR DESCRIPTION
We were running into an issue with the new uploader... With the functionality added by the cropping tool we noticed that the urls we were receiving from uploads already had `/convert?crop=...` appended to them. As a result, we were getting some urls like `filepicker.io/convert?crop=0,0,1,1/convert?cache=true&watersize=70`