### PR TITLE
crop-first param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+- Support for `crop-first` parameter when linking to an image.
+
 ## 2.0.0 (July, 15, 2015)
 
 - Properly-released version 1.5.0 and 1.5.1.

--- a/app/helpers/filepicker_rails/application_helper.rb
+++ b/app/helpers/filepicker_rails/application_helper.rb
@@ -171,7 +171,8 @@ module FilepickerRails
     class FilepickerImageUrl
 
       CONVERT_OPTIONS = [:w, :h, :fit, :align, :rotate, :crop, :format,
-                         :quality, :watermark, :watersize, :waterposition]
+                         :quality, :watermark, :watersize, :waterposition,
+                         :crop_first]
       VALID_OPTIONS   = CONVERT_OPTIONS + [:cache]
 
       def initialize(url, options = {})

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -241,6 +241,11 @@ RSpec.describe FilepickerRails::ApplicationHelper do
         expect(filepicker_image_url("foo", waterposition: 'top')).to eq('foo/convert?waterposition=top')
       end
 
+      it "have correct url with 'crop_first'" do
+        url = 'foo/convert?crop_first=true'
+        expect(filepicker_image_url("foo", crop_first: true)).to eq(url)
+      end
+
       describe 'cache' do
 
         it "have correct url with 'cache' only" do


### PR DESCRIPTION
As discussed in #127. 

I do have a problem with cropping though. It seems that sometimes when users upload something and crop it, I get an URL that already has `/convert?crop=...` present. The `FilepickerImageUrl` class doesn't seem to handle that very well and generates links with `crop` query parameter doubled. Is this me or possibly a topic for another issue?